### PR TITLE
Disallow prototype path override - check magic attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,23 +10,23 @@ module.exports = {
   delete: del
 }
 
-var ILLEGAL_KEYS = ["constructor", "__proto__"];
+var ILLEGAL_KEYS = ['constructor', '__proto__']
 
 function isIllegalKey (key) {
-  return ILLEGAL_KEYS.indexOf(key) !== -1;
+  return ILLEGAL_KEYS.indexOf(key) !== -1
 }
 
-function isProtoPath(path) {
+function isProtoPath (path) {
   return Array.isArray(path)
     ? path.some(isIllegalKey)
-    : typeof path === "string"
+    : typeof path === 'string'
       ? isIllegalKey(path)
-      : false;
+      : false
 }
 
 function disallowProtoPath (path) {
   if (isProtoPath(path)) {
-    throw new Error("Unsafe path encountered: " + path);
+    throw new Error('Unsafe path encountered: ' + path)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,26 @@ module.exports = {
   delete: del
 }
 
+var ILLEGAL_KEYS = ["constructor", "__proto__"];
+
+function isIllegalKey (key) {
+  return ILLEGAL_KEYS.indexOf(key) !== -1;
+}
+
+function isProtoPath(path) {
+  return Array.isArray(path)
+    ? path.some(isIllegalKey)
+    : typeof path === "string"
+      ? isIllegalKey(path)
+      : false;
+}
+
+function disallowProtoPath (path) {
+  if (isProtoPath(path)) {
+    throw new Error("Unsafe path encountered: " + path);
+  }
+}
+
 function get (data, key, split) {
   if (!key) return xtend(data)
   var keys = parseKeys(key, split)
@@ -29,6 +49,7 @@ function get (data, key, split) {
 function set (data, key, value, split, original) {
   original = original || data
   var keys = parseKeys(key, split)
+  disallowProtoPath(keys)
   var current = keys[0]
   var next = keys[1]
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -74,3 +74,11 @@ test('setting missing keys creates them', function (t) {
   t.equal(data.missing.nested, 'huh')
   t.end()
 })
+
+test('disallow protopath override', function (t) {
+  var obj = {}
+
+  t.throws(() => keypath.set(obj, '__proto__.polluted', 'Yes'))
+  t.throws(() => keypath.set(obj, 'constructor.prototype.polluted', 'Yes'))
+  t.end()
+})


### PR DESCRIPTION
### 📊 Metadata *

`obj-keypath` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-obj-keypath/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```javascript
// poc.js
var keypath = require("obj-keypath")

var obj = {};
console.log("Before: " + {}.polluted);
keypath.set(obj, "__proto__.polluted", "Yes, its polluted")
console.log("After: ", {}.polluted);
```
2. Execute the following commands in the terminal:

```bash
npm i obj-keypath # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:

```
Before: undefined
After: Yes, its polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106452903-8564e080-64ae-11eb-8808-16881b88d211.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106452948-96155680-64ae-11eb-9e85-74b7d45a812c.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106454318-90207500-64b0-11eb-9e6f-459a3d129d96.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1819
